### PR TITLE
Seasonal stats redesign

### DIFF
--- a/DragonFruit.Six.Client/Screens/Stats/AccountSaveControl.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/AccountSaveControl.razor
@@ -11,7 +11,7 @@
 
 @code {
 
-    private Realm _realm;
+    private Realm _notificationRealm;
     private IDisposable _notificationListener;
 
     [Parameter]
@@ -20,45 +20,47 @@
     [Inject]
     public IMapper Mapper { get; set; }
 
-    public bool IsSaved { get; set; }
+    private bool IsSaved { get; set; }
 
     protected override void OnParametersSet()
     {
         Dispose();
-        _realm = Realm.GetInstance();
+        _notificationRealm = Realm.GetInstance();
 
         _notificationListener?.Dispose();
-        _notificationListener = _realm.All<SavedAccount>().SubscribeForNotifications((sender, _, _) =>
+        _notificationListener = _notificationRealm.All<SavedAccount>().SubscribeForNotifications((sender, _, _) =>
         {
             IsSaved = sender.Any(x => x.ProfileId == Account.ProfileId);
             InvokeAsync(StateHasChanged);
         });
     }
 
-    private void ToggleSave()
+    private async Task ToggleSave()
     {
+        using var realm = await Realm.GetInstanceAsync();
+        using var transaction = await realm.BeginWriteAsync();
+
         if (IsSaved)
         {
-            _realm.Write(() =>
+            var account = realm.Find<SavedAccount>(Account.ProfileId);
+            if (account != null)
             {
-                var account = _realm.Find<SavedAccount>(Account.ProfileId);
-                if (account != null)
-                {
-                    _realm.Remove(account);
-                }
-            });
+                realm.Remove(account);
+            }
         }
         else
         {
             var savedAccount = Mapper.Map<SavedAccount>(Account);
-            _realm.Write(() => _realm.Add(savedAccount));
+            realm.Write(() => _notificationRealm.Add(savedAccount));
         }
+
+        await transaction.CommitAsync().ConfigureAwait(false);
     }
 
     public void Dispose()
     {
         _notificationListener?.Dispose();
-        _realm?.Dispose();
+        _notificationRealm?.Dispose();
     }
 
 }

--- a/DragonFruit.Six.Client/Screens/Stats/SeasonalRankTypeDisplay.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/SeasonalRankTypeDisplay.razor
@@ -1,0 +1,25 @@
+﻿@using DragonFruit.Six.Client.Database.Entities
+@using DragonFruit.Six.Api.Seasonal.Entities
+
+<div class="d6-season-rank-type-card">
+    <StatsSeasonCard SeasonInfo="Info" TitleOverride="@Title" Rank="Rank"/>
+    <div class="d6-stats-list">
+        @ChildContent
+    </div>
+</div>
+
+@code {
+
+    [Parameter]
+    public SeasonInfo Info { get; set; }
+
+    [Parameter]
+    public RankInfo Rank { get; set; }
+
+    [Parameter]
+    public string Title { get; set; }
+
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
+}

--- a/DragonFruit.Six.Client/Screens/Stats/SeasonalRankTypeDisplay.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/SeasonalRankTypeDisplay.razor
@@ -1,7 +1,7 @@
 ﻿@using DragonFruit.Six.Client.Database.Entities
 @using DragonFruit.Six.Api.Seasonal.Entities
 
-<div class="d6-season-rank-type-card">
+<div class="d6-season-rank-type-card d-md-flex">
     <StatsSeasonCard SeasonInfo="Info" TitleOverride="@Title" Rank="Rank"/>
     <div class="d6-stats-list">
         @ChildContent

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonCard.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonCard.razor
@@ -31,6 +31,8 @@
         {
             IsRankReal = false;
             RankInfo = Season.Stats.MMRRankInfo;
+
+            return;
         }
 
         switch (Season.Ranked2Stats?.Board)
@@ -52,9 +54,9 @@
                 break;
         }
 
-        // board is real rank if it's ranked and either:
-        // 1) the season is pre ranked2 (less than 28)
-        // 2) there are ranked2 stats
+    // board is real rank if it's ranked and either:
+    // 1) the season is pre ranked2 (less than 28)
+    // 2) there are ranked2 stats
         IsRankReal = Season.Stats.Board == BoardType.Ranked && (Season.Ranked2Stats != null || Season.Stats.SeasonId < 28);
     }
 

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonCard.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonCard.razor
@@ -2,15 +2,12 @@
 @using DragonFruit.Six.Api.Seasonal.Entities
 @using DragonFruit.Six.Client.Utils
 @using SeasonInfo = DragonFruit.Six.Client.Database.Entities.SeasonInfo
-@{
-    var isRealRank = GetDisplayedRank(out var rankInfo);
-}
 
 <div class="d6-season-card justify-content-md-center" id="d6-season-@Season.Info.Season" role="button" @onclick="() => OnSeasonSelected.InvokeAsync(Season)">
-    <img src="@RankIconUtils.FormatRankIconUrl(rankInfo.IconUrl)" alt="@rankInfo.Name" class="d6-season-rank user-select-none @(isRealRank ? null : "d6-season-rank-mmr")">
+    <img src="@RankIconUtils.FormatRankIconUrl(RankInfo.IconUrl)" alt="@RankInfo.Name" class="d6-season-rank user-select-none @(IsRankReal ? null : "d6-season-rank-mmr")">
     <div class="d-flex flex-column ms-2">
         <span class="text-truncate" style="color: @Season.Info.AccentColour">@Season.Info.SeasonName</span>
-        <h4 class="m-0">@rankInfo.Name</h4>
+        <h4 class="m-0">@RankInfo.Name</h4>
     </div>
 </div>
 
@@ -25,40 +22,40 @@
     [Parameter]
     public EventCallback<SeasonalStatsContainer> OnSeasonSelected { get; set; }
 
-    /// <summary>
-    /// Gets the <see cref="RankInfo"/> to display in the card, returning true if the rank was actually obtained by the user
-    /// </summary>
-    private bool GetDisplayedRank(out RankInfo rankInfo)
+    private bool IsRankReal { get; set; }
+    private RankInfo RankInfo { get; set; }
+
+    protected override void OnParametersSet()
     {
         if (Season.Stats.Board != BoardType.Ranked && Season.Stats.Wins + Season.Stats.Losses + Season.Stats.Abandons > 0)
         {
-            rankInfo = Season.Stats.MMRRankInfo;
-            return false;
+            IsRankReal = false;
+            RankInfo = Season.Stats.MMRRankInfo;
         }
 
         switch (Season.Ranked2Stats?.Board)
         {
             case BoardType.Ranked when DisplayMaxRank:
-                rankInfo = Season.Ranked2Stats.MaxRankInfo;
+                RankInfo = Season.Ranked2Stats.MaxRankInfo;
                 break;
 
             case BoardType.Ranked:
-                rankInfo = Season.Ranked2Stats.RankInfo;
+                RankInfo = Season.Ranked2Stats.RankInfo;
                 break;
 
             case null when DisplayMaxRank:
-                rankInfo = Season.Stats.MaxRankInfo;
+                RankInfo = Season.Stats.MaxRankInfo;
                 break;
 
             default:
-                rankInfo = Season.Stats.RankInfo;
+                RankInfo = Season.Stats.RankInfo;
                 break;
         }
 
         // board is real rank if it's ranked and either:
         // 1) the season is pre ranked2 (less than 28)
         // 2) there are ranked2 stats
-        return Season.Stats.Board == BoardType.Ranked && (Season.Ranked2Stats != null || Season.Stats.SeasonId < 28);
+        IsRankReal = Season.Stats.Board == BoardType.Ranked && (Season.Ranked2Stats != null || Season.Stats.SeasonId < 28);
     }
 
 }

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonCard.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonCard.razor
@@ -3,17 +3,11 @@
 @using DragonFruit.Six.Client.Utils
 @using SeasonInfo = DragonFruit.Six.Client.Database.Entities.SeasonInfo
 @{
-    var rankInfo = IsCasualRank switch
-    {
-        true => Season.Stats.MMRRankInfo,
-        false when DisplayMaxRank => Season.Stats.MaxRankInfo,
-
-        _ => Season.Stats.RankInfo
-    };
+    var isRealRank = GetDisplayedRank(out var rankInfo);
 }
 
 <div class="d6-season-card justify-content-md-center" id="d6-season-@Season.Info.Season" role="button" @onclick="() => OnSeasonSelected.InvokeAsync(Season)">
-    <img src="@RankIconUtils.FormatRankIconUrl(rankInfo.IconUrl)" alt="@rankInfo.Name" class="d6-season-rank user-select-none @(IsCasualRank ? "d6-season-rank-mmr" : null)">
+    <img src="@RankIconUtils.FormatRankIconUrl(rankInfo.IconUrl)" alt="@rankInfo.Name" class="d6-season-rank user-select-none @(isRealRank ? null : "d6-season-rank-mmr")">
     <div class="d-flex flex-column ms-2">
         <span class="text-truncate" style="color: @Season.Info.AccentColour">@Season.Info.SeasonName</span>
         <h4 class="m-0">@rankInfo.Name</h4>
@@ -31,5 +25,40 @@
     [Parameter]
     public EventCallback<SeasonalStatsContainer> OnSeasonSelected { get; set; }
 
-    private bool IsCasualRank => Season.Stats.Board == BoardType.Casual && Season.Stats.Wins + Season.Stats.Losses + Season.Stats.Abandons > 0;
+    /// <summary>
+    /// Gets the <see cref="RankInfo"/> to display in the card, returning true if the rank was actually obtained by the user
+    /// </summary>
+    private bool GetDisplayedRank(out RankInfo rankInfo)
+    {
+        if (Season.Stats.Board != BoardType.Ranked && Season.Stats.Wins + Season.Stats.Losses + Season.Stats.Abandons > 0)
+        {
+            rankInfo = Season.Stats.MMRRankInfo;
+            return false;
+        }
+
+        switch (Season.Ranked2Stats?.Board)
+        {
+            case BoardType.Ranked when DisplayMaxRank:
+                rankInfo = Season.Ranked2Stats.MaxRankInfo;
+                break;
+
+            case BoardType.Ranked:
+                rankInfo = Season.Ranked2Stats.RankInfo;
+                break;
+
+            case null when DisplayMaxRank:
+                rankInfo = Season.Stats.MaxRankInfo;
+                break;
+
+            default:
+                rankInfo = Season.Stats.RankInfo;
+                break;
+        }
+
+        // board is real rank if it's ranked and either:
+        // 1) the season is pre ranked2 (less than 28)
+        // 2) there are ranked2 stats
+        return Season.Stats.Board == BoardType.Ranked && (Season.Ranked2Stats != null || Season.Stats.SeasonId < 28);
+    }
+
 }

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonCard.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonCard.razor
@@ -1,63 +1,32 @@
 ﻿@using DragonFruit.Six.Api.Seasonal.Enums
 @using DragonFruit.Six.Api.Seasonal.Entities
 @using DragonFruit.Six.Client.Utils
+@using JetBrains.Annotations
 @using SeasonInfo = DragonFruit.Six.Client.Database.Entities.SeasonInfo
 
-<div class="d6-season-card justify-content-md-center" id="d6-season-@Season.Info.Season" role="button" @onclick="() => OnSeasonSelected.InvokeAsync(Season)">
-    <img src="@RankIconUtils.FormatRankIconUrl(RankInfo.IconUrl)" alt="@RankInfo.Name" class="d6-season-rank user-select-none @(IsRankReal ? null : "d6-season-rank-mmr")">
+<div class="d6-season-card justify-content-md-center" id="d6-season-@SeasonInfo.Season" @onclick="Clicked" role="@(Clicked.HasDelegate ? "button" : "none")">
+    <img src="@RankIconUtils.FormatRankIconUrl(Rank.IconUrl)" alt="@Rank.Name" class="d6-season-rank user-select-none @(Provisional ? "d6-season-rank-mmr" : null)">
     <div class="d-flex flex-column ms-2">
-        <span class="text-truncate" style="color: @Season.Info.AccentColour">@Season.Info.SeasonName</span>
-        <h4 class="m-0">@RankInfo.Name</h4>
+        <span class="text-truncate" style="color: @SeasonInfo.AccentColour">@(TitleOverride ?? SeasonInfo.SeasonName)</span>
+        <h4 class="m-0">@Rank.Name</h4>
     </div>
 </div>
 
 @code {
 
     [Parameter]
-    public bool DisplayMaxRank { get; set; }
+    public SeasonInfo SeasonInfo { get; set; }
 
     [Parameter]
-    public SeasonalStatsContainer Season { get; set; }
+    public RankInfo Rank { get; set; }
 
     [Parameter]
-    public EventCallback<SeasonalStatsContainer> OnSeasonSelected { get; set; }
+    public bool Provisional { get; set; }
 
-    private bool IsRankReal { get; set; }
-    private RankInfo RankInfo { get; set; }
+    [Parameter, CanBeNull]
+    public string TitleOverride { get; set; }
 
-    protected override void OnParametersSet()
-    {
-        if (Season.Stats.Board != BoardType.Ranked && Season.Stats.Wins + Season.Stats.Losses + Season.Stats.Abandons > 0)
-        {
-            IsRankReal = false;
-            RankInfo = Season.Stats.MMRRankInfo;
-
-            return;
-        }
-
-        switch (Season.Ranked2Stats?.Board)
-        {
-            case BoardType.Ranked when DisplayMaxRank:
-                RankInfo = Season.Ranked2Stats.MaxRankInfo;
-                break;
-
-            case BoardType.Ranked:
-                RankInfo = Season.Ranked2Stats.RankInfo;
-                break;
-
-            case null when DisplayMaxRank:
-                RankInfo = Season.Stats.MaxRankInfo;
-                break;
-
-            default:
-                RankInfo = Season.Stats.RankInfo;
-                break;
-        }
-
-    // board is real rank if it's ranked and either:
-    // 1) the season is pre ranked2 (less than 28)
-    // 2) there are ranked2 stats
-        IsRankReal = Season.Stats.Board == BoardType.Ranked && (Season.Ranked2Stats != null || Season.Stats.SeasonId < 28);
-    }
+    [Parameter]
+    public EventCallback Clicked { get; set; }
 
 }

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonDetails.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonDetails.razor
@@ -54,9 +54,6 @@
 @code {
 
     [Parameter]
-    public bool DisplayMaxRank { get; set; }
-
-    [Parameter]
     public SeasonalStatsContainer Season { get; set; }
 
 }

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonDetails.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonDetails.razor
@@ -5,6 +5,37 @@
 @using SeasonInfo = DragonFruit.Six.Client.Database.Entities.SeasonInfo
 
 <div>
+    <div class="d6-season-rank-type-container">
+        @if (Season.Ranked2Stats?.Board == BoardType.Ranked)
+        {
+            <SeasonalRankTypeDisplay Info="Season.Info" Title="Progression" Rank="Season.Ranked2Stats.MaxRankInfo">
+                <dl>
+                    <dt>Rank Poins</dt>
+                    <dd>@Season.Ranked2Stats.RankPoints RP</dd>
+                </dl>
+                <dl>
+                    <dt>Max Rank Points</dt>
+                    <dd>@Season.Ranked2Stats.MaxRankPoints RP</dd>
+                </dl>
+            </SeasonalRankTypeDisplay>
+        }
+
+        <SeasonalRankTypeDisplay Info="Season.Info" Title="Skill" Rank="Season.Stats.MaxRankInfo">
+            <dl>
+                <dt>MMR</dt>
+                <dd>@Season.Stats.MMR.ToString("N0") (@Season.Stats.MMRRankInfo.Name)</dd>
+            </dl>
+            <dl>
+                <dt>Max MMR</dt>
+                <dd>@Season.Stats.MaxMMR.ToString("N0")</dd>
+            </dl>
+            <dl>
+                <dt>Uncertainty</dt>
+                <dd>&plusmn; @((Season.Stats.SkillUncertainty * 100).ToString("N0"))</dd>
+            </dl>
+        </SeasonalRankTypeDisplay>
+    </div>
+
     <div class="d6-stat-container mt-4">
         <StatsAggregationCard Title="@($"{Season.Info.SeasonName} K/D")" Progress="Season.Stats.Kd / 0.02f">
             <StatsAggregationCardDescriptor>@Season.Stats.Kd.ToString("0.00") K/D</StatsAggregationCardDescriptor>
@@ -18,36 +49,6 @@
             <StatsAggregationCardDescriptor CssClass="text-danger">@Season.Stats.Losses.ToString("N0") Losses</StatsAggregationCardDescriptor>
             <StatsAggregationCardDescriptor CssClass="text-secondary">@Season.Stats.Abandons.ToString("N0") Abandons</StatsAggregationCardDescriptor>
         </StatsAggregationCard>
-    </div>
-    <div class="d6-icon-stats mt-4">
-        @if (Season.Stats.Board == BoardType.Ranked)
-        {
-            <div>
-                <img src="@RankIconUtils.FormatRankIconUrl(Season.Stats.MaxRankInfo.IconUrl)" alt="final rank" height="48" class="mb-3"/>
-                <h5>@Season.Stats.MaxRankInfo.Name</h5>
-                <p class="text-secondary">Final Rank</p>
-            </div>
-        }
-
-        <div>
-            <i class="fa-solid fa-chart-line fa-3x mb-3"></i>
-            <h5>@Season.Stats.MMR.ToString("N0") MMR</h5>
-            <p class="text-secondary">&PlusMinus; @((Season.Stats.SkillUncertainty * 100).ToString("N0")) Skill Uncertainty</p>
-        </div>
-
-        @if (Season.Stats.Board == BoardType.Ranked && Season.Stats.MaxRank > 0)
-        {
-            <div>
-                <i class="fa-solid fa-trophy fa-3x mb-3"></i>
-                <h5>@Season.Stats.MaxMMR.ToString("N0") Max MMR</h5>
-            </div>
-        }
-
-        <div>
-            <i class="fa-solid fa-clock-rotate-left fa-3x mb-3"></i>
-            <h5>Last Match @Season.Stats.LastMatchResult.Humanize()</h5>
-            <p class="text-secondary">@((Season.Stats.LastMatchSkillChange * 100).ToString("N0")) MMR Change</p>
-        </div>
     </div>
 </div>
 

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonDetails.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonDetails.razor
@@ -11,24 +11,29 @@
             <SeasonalRankTypeDisplay Info="Season.Info" Title="Progression" Rank="Season.Ranked2Stats.MaxRankInfo">
                 <dl>
                     <dt>Rank Poins</dt>
-                    <dd>@Season.Ranked2Stats.RankPoints RP</dd>
+                    <dd>@Season.Ranked2Stats.RankPoints.ToString("N0")</dd>
                 </dl>
                 <dl>
                     <dt>Max Rank Points</dt>
-                    <dd>@Season.Ranked2Stats.MaxRankPoints RP</dd>
+                    <dd>@Season.Ranked2Stats.MaxRankPoints.ToString("N0")</dd>
                 </dl>
             </SeasonalRankTypeDisplay>
         }
 
-        <SeasonalRankTypeDisplay Info="Season.Info" Title="Skill" Rank="Season.Stats.MaxRankInfo">
+        <SeasonalRankTypeDisplay Info="Season.Info" Title="Skill" Rank="@(Season.Stats.Board == BoardType.Ranked ? Season.Stats.MaxRankInfo : Season.Stats.MMRRankInfo)">
             <dl>
                 <dt>MMR</dt>
-                <dd>@Season.Stats.MMR.ToString("N0") (@Season.Stats.MMRRankInfo.Name)</dd>
+                <dd>@Season.Stats.MMR.ToString("N0")</dd>
             </dl>
-            <dl>
-                <dt>Max MMR</dt>
-                <dd>@Season.Stats.MaxMMR.ToString("N0")</dd>
-            </dl>
+            
+            @if (Season.Stats.Board == BoardType.Ranked)
+            {
+                <dl>
+                    <dt>Max MMR</dt>
+                    <dd>@Season.Stats.MaxMMR.ToString("N0")</dd>
+                </dl>
+            }
+
             <dl>
                 <dt>Uncertainty</dt>
                 <dd>&plusmn; @((Season.Stats.SkillUncertainty * 100).ToString("N0"))</dd>

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor
@@ -7,7 +7,7 @@
             <div class="d6-season-cards d-md-grid">
                 @foreach (var season in Boards[SelectedBoard].Skip((Page - 1) * 4).Take(EntriesPerPage))
                 {
-                    <StatsSeasonCard Season="@season" DisplayMaxRank="@DisplayMaxRank" OnSeasonSelected="SetSelectedSeason"/>
+                    <StatsSeasonCard Season="@season" DisplayMaxRank="true" OnSeasonSelected="SetSelectedSeason"/>
                 }
             </div>
 
@@ -52,6 +52,6 @@
     @if (SelectedSeason != null)
     {
         <hr class="text-secondary mt-3"/>
-        <StatsSeasonDetails Season="SelectedSeason" DisplayMaxRank="DisplayMaxRank"/>
+        <StatsSeasonDetails Season="SelectedSeason"/>
     }
 </div>

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor
@@ -7,7 +7,10 @@
             <div class="d6-season-cards d-md-grid">
                 @foreach (var season in Boards[SelectedBoard].Skip((Page - 1) * 4).Take(EntriesPerPage))
                 {
-                    <StatsSeasonCard Season="@season" DisplayMaxRank="true" OnSeasonSelected="SetSelectedSeason"/>
+                    <StatsSeasonCard SeasonInfo="season.Info"
+                                     Rank="season.GetDisplayRank()"
+                                     Clicked="() => SetSelectedSeason(season)"
+                                     Provisional="!season.IsObtainedRankAvailable"/>
                 }
             </div>
 

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor.cs
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor.cs
@@ -22,7 +22,6 @@ namespace DragonFruit.Six.Client.Screens.Stats
 {
     public partial class StatsSeasonal
     {
-        private const bool DisplayMaxRank = true;
         private const int EntriesPerPage = 4;
 
         [Inject]

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor.cs
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor.cs
@@ -119,5 +119,28 @@ namespace DragonFruit.Six.Client.Screens.Stats
         /// </summary>
         [CanBeNull]
         public Ranked2SeasonStats Ranked2Stats { get; set; }
+
+        /// <summary>
+        /// Gets whether the player's real rank is available in this container
+        /// </summary>
+        public bool IsObtainedRankAvailable => Stats.Board == BoardType.Ranked && (Ranked2Stats != null || Stats.SeasonId < 28);
+
+        public RankInfo GetDisplayRank()
+        {
+            var totalMatchesPlayed = Stats.Wins + Stats.Losses + Stats.Abandons;
+
+            if (Stats.Board != BoardType.Ranked && totalMatchesPlayed > 0)
+            {
+                return Stats.MMRRankInfo;
+            }
+
+            // use mmr for ranks for placement matches pre-ranked 2.0
+            if (Stats.Board == BoardType.Ranked && Stats.SeasonId < 28 && totalMatchesPlayed is > 0 and < 10)
+            {
+                return Stats.MMRRankInfo;
+            }
+
+            return Ranked2Stats?.Board == BoardType.Ranked ? Ranked2Stats.MaxRankInfo : Stats.MaxRankInfo;
+        }
     }
 }

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor.cs
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor.cs
@@ -7,10 +7,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using DragonFruit.Six.Api;
 using DragonFruit.Six.Api.Accounts.Entities;
+using DragonFruit.Six.Api.Accounts.Enums;
+using DragonFruit.Six.Api.Enums;
 using DragonFruit.Six.Api.Seasonal;
 using DragonFruit.Six.Api.Seasonal.Entities;
 using DragonFruit.Six.Api.Seasonal.Enums;
 using DragonFruit.Six.Client.Configuration;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Components;
 using Realms;
 using SeasonInfo = DragonFruit.Six.Client.Database.Entities.SeasonInfo;
@@ -59,6 +62,8 @@ namespace DragonFruit.Six.Client.Screens.Stats
             Page = 1;
             Boards = preloadedSeasons.ToLookup(x => x.Stats.Board);
 
+            _ = InvokeAsync(StateHasChanged);
+
             // because realm can't process Contains(), we need to use the smallest season id we retrieved and go backwards from there.
             var lastPrefetchedSeason = PreloadedStats.Min(y => y.SeasonId);
             var missingSeasonInfo = realm.All<SeasonInfo>()
@@ -69,9 +74,17 @@ namespace DragonFruit.Six.Client.Screens.Stats
 
             var missingSeasonStats = await Client.GetSeasonalStatsRecordsAsync(Account, missingSeasonInfo.Select(x => (int)x.SeasonId), BoardType.Ranked | BoardType.Casual, Configuration.Get<Region>(Dragon6Setting.LegacyStatsRegion)).ConfigureAwait(false);
             var additionalSeasons = missingSeasonStats.Join(missingSeasonInfo, x => x.SeasonId, x => x.SeasonId, (s, i) => new SeasonalStatsContainer(i, s));
+            var combinedSeasons = preloadedSeasons.Concat(additionalSeasons).OrderByDescending(x => x.Info.SeasonId).ToList();
 
+            var ranked2Stats = await Client.GetSeasonalStatsAsync(Account, Account.Platform == Platform.PC ? PlatformGroup.PC : PlatformGroup.Console).ConfigureAwait(false);
+
+            foreach (var targetSeason in combinedSeasons.Where(x => x.Stats.SeasonId == ranked2Stats.First().SeasonId))
+            {
+                targetSeason.Ranked2Stats = ranked2Stats.SingleOrDefault(x => x.SeasonId == targetSeason.Stats.SeasonId && x.Board == targetSeason.Stats.Board);
+            }
+
+            Boards = combinedSeasons.ToLookup(x => x.Stats.Board);
             SelectedBoard = Configuration.Get<BoardType>(Dragon6Setting.DefaultSeasonalType);
-            Boards = preloadedSeasons.Concat(additionalSeasons).OrderByDescending(x => x.Info.SeasonId).ToLookup(x => x.Stats.Board);
         }
 
         private void ChangePage(int pageDelta)
@@ -98,7 +111,13 @@ namespace DragonFruit.Six.Client.Screens.Stats
             Stats = stats;
         }
 
-        public SeasonInfo Info { get; set; }
-        public SeasonalStats Stats { get; set; }
+        public SeasonInfo Info { get; }
+        public SeasonalStats Stats { get; }
+
+        /// <summary>
+        /// Ranked 2.0 stats for the season, if available
+        /// </summary>
+        [CanBeNull]
+        public Ranked2SeasonStats Ranked2Stats { get; set; }
     }
 }

--- a/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor.cs
+++ b/DragonFruit.Six.Client/Screens/Stats/StatsSeasonal.razor.cs
@@ -76,6 +76,7 @@ namespace DragonFruit.Six.Client.Screens.Stats
             var additionalSeasons = missingSeasonStats.Join(missingSeasonInfo, x => x.SeasonId, x => x.SeasonId, (s, i) => new SeasonalStatsContainer(i, s));
             var combinedSeasons = preloadedSeasons.Concat(additionalSeasons).OrderByDescending(x => x.Info.SeasonId).ToList();
 
+            // todo add a utility that evaluates the enumerable and returns a collection-based result
             var ranked2Stats = await Client.GetSeasonalStatsAsync(Account, Account.Platform == Platform.PC ? PlatformGroup.PC : PlatformGroup.Console).ConfigureAwait(false);
 
             foreach (var targetSeason in combinedSeasons.Where(x => x.Stats.SeasonId == ranked2Stats.First().SeasonId))

--- a/DragonFruit.Six.Client/wwwroot/styles/stats.css
+++ b/DragonFruit.Six.Client/wwwroot/styles/stats.css
@@ -42,6 +42,10 @@
     user-select: none;
 }
 
+.d6-season-rank-type-card .d6-season-card {
+    width: unset !important;
+}
+
 .d6-season-board-selector::after {
     display: none !important;
 }
@@ -55,23 +59,28 @@ img.d6-season-rank-mmr {
     opacity: 0.5;
 }
 
-.d6-season-stats {
-    display: flex;
-    align-items: center;
-    margin: 0 .5rem;
-}
-
-.d6-seasonal-stats-detail {
-    display: flex;
-    gap: 20px;
-}
-
-.d6-seasonal-stats-detail > div {
+.d6-stats-list {
     display: grid;
-    column-gap: 15px;
-    grid-template-columns: 30px 1fr;
+    gap: 4px 20px;
+    align-self: center;
+    grid-template-columns: repeat(2, 1fr);
+}
+
+.d6-stats-list > dl {
+    display: contents;
+}
+
+.d6-season-rank-type-container {
+    gap: 20px;
+    display: grid;
     align-items: center;
-    justify-content: center;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+}
+
+.d6-season-rank-type-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .d6-progress {

--- a/DragonFruit.Six.Client/wwwroot/styles/stats.css
+++ b/DragonFruit.Six.Client/wwwroot/styles/stats.css
@@ -59,17 +59,6 @@ img.d6-season-rank-mmr {
     opacity: 0.5;
 }
 
-.d6-stats-list {
-    display: grid;
-    gap: 4px 20px;
-    align-self: center;
-    grid-template-columns: repeat(2, 1fr);
-}
-
-.d6-stats-list > dl {
-    display: contents;
-}
-
 .d6-season-rank-type-container {
     gap: 20px;
     display: grid;
@@ -78,9 +67,28 @@ img.d6-season-rank-mmr {
 }
 
 .d6-season-rank-type-card {
-    display: flex;
+    gap: 15px;
+    display: grid;
+    grid-template-columns: 1fr;
+
     align-items: center;
     justify-content: space-between;
+}
+
+.d6-stats-list {
+    display: grid;
+    gap: 10px 20px;
+    align-self: center;
+    align-items: center;
+    grid-template-columns: repeat(2, auto);
+}
+
+.d6-stats-list > dl {
+    display: contents;
+}
+
+.d6-stats-list dd {
+    margin: 0;
 }
 
 .d6-progress {


### PR DESCRIPTION
Adds ranked2 stats to the season selector. Ranked2 seasons that have passed will end up looking like casual ranks due to the lack of persistent storage on ubi's end, but MMR-based ranks will not be removed.